### PR TITLE
Adiciona testes para o código do servidor

### DIFF
--- a/blogproject/server/app.js
+++ b/blogproject/server/app.js
@@ -1,0 +1,38 @@
+var express = require('express');
+var cors = require('cors');
+var app = express();
+
+var jwt = require('express-jwt');
+var dotenv = require('dotenv');
+
+dotenv.load();
+
+var authenticate = jwt({
+  secret: new Buffer(process.env.AUTH0_CLIENT_SECRET, 'base64'),
+  audience: process.env.AUTH0_CLIENT_ID
+});
+
+
+app.configure(function () {
+  // Request body parsing middleware should be above methodOverride
+  app.use(express.bodyParser()); // TODO: add test for it
+  app.use(express.urlencoded()); // TODO: add test for it
+  app.use(express.json()); // TODO: add test for it
+
+
+  app.use('/secured', authenticate);
+  app.use(cors());
+
+  app.use(app.router);  // TODO: add test for it, maybe delete it
+});
+
+
+app.get('/ping', function(req, res) {
+  res.send(200, {text: "Resposta OK de método desprotegido!"});
+});
+
+app.get('/secured/ping', function(req, res) {
+  res.send(200, {text: "Resposta OK de método protegido, você está autenticado!"});
+});
+
+module.exports = app;

--- a/blogproject/server/package.json
+++ b/blogproject/server/package.json
@@ -6,6 +6,7 @@
   "author": "Martin Gontovnikas",
   "license": "MIT",
   "dependencies": {
+    "chai": "^3.2.0",
     "cors": "^2.3.1",
     "dotenv": "^0.2.8",
     "express": "~3.3.8",
@@ -13,5 +14,9 @@
   },
   "engines": {
     "node": "0.10.x"
+  },
+  "devDependencies": {
+    "jsonwebtoken": "^5.0.4",
+    "supertest": "^1.0.1"
   }
 }

--- a/blogproject/server/server.js
+++ b/blogproject/server/server.js
@@ -1,39 +1,5 @@
 var http = require('http');
-var express = require('express');
-var cors = require('cors');
-var app = express();
-var jwt = require('express-jwt');
-var dotenv = require('dotenv');
-
-dotenv.load();
-
-var authenticate = jwt({
-  secret: new Buffer(process.env.AUTH0_CLIENT_SECRET, 'base64'),
-  audience: process.env.AUTH0_CLIENT_ID
-});
-
-
-app.configure(function () {
-
- // Request body parsing middleware should be above methodOverride
-  app.use(express.bodyParser());
-  app.use(express.urlencoded());
-  app.use(express.json());
-
-  app.use('/secured', authenticate);
-  app.use(cors());
-
-  app.use(app.router);
-});
-
-
-app.get('/ping', function(req, res) {
-  res.send(200, {text: "Resposta OK de método desprotegido!"});
-});
-
-app.get('/secured/ping', function(req, res) {
-  res.send(200, {text: "Resposta OK de método protegido, você está autenticado!"});
-})
+var app = require('./app');
 
 var port = process.env.PORT || 3001;
 

--- a/blogproject/server/test/server_test.js
+++ b/blogproject/server/test/server_test.js
@@ -1,0 +1,46 @@
+var app = require('../app');
+var request = require('supertest');
+var jwt = require('jsonwebtoken');
+var dotenv = require('dotenv');
+
+dotenv.load();
+
+describe('Server API', function () {
+  describe('with a unauthenticated user', function () {
+    it('returns http status 200 to /ping with json type', function (done) {
+      request(app)
+        .get('/ping')
+        .expect('Content-Type', /json/)
+        .expect(200, done)
+    });
+
+    it('returns http status 401 to /secured/ping', function (done) {
+      request(app)
+        .get('/secured/ping')
+        .expect(401, done)
+    });
+  });
+
+  describe('with a authenticate user', function () {
+    var token;
+    beforeEach(function () {
+      var secret = new Buffer(process.env.AUTH0_CLIENT_SECRET, 'base64');
+      token = jwt.sign({foo: 'bar', aud: process.env.AUTH0_CLIENT_ID}, secret);
+    });
+
+    it('returns 200 to /secured/ping', function (done) {
+      request(app)
+        .get('/secured/ping')
+        .set('Authorization', 'Bearer ' + token)
+        .expect(200, done)
+    });
+  });
+
+  it('returns CORS headers to OPTIONS request', function (done) {
+    request(app)
+      .options('/ping')
+      .expect('Access-Control-Allow-Origin', '*')
+      .expect('Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE')
+      .expect(204, done)
+  });
+});


### PR DESCRIPTION
Esse pull-request será usado como exemplo para apresentação de hoje.
- O codigo de server.js referente a 'app' foi movido para 'app.js' para torna-lo testavel
- Foi adicionado uma lib chamada jsonwebtoken para criar os token validos para jwt no testes
